### PR TITLE
Fix @click not working on BaseSwitch

### DIFF
--- a/components/BaseSwitch.vue
+++ b/components/BaseSwitch.vue
@@ -41,6 +41,7 @@ export default {
   methods: {
     triggerToggle() {
       this.model = !this.model;
+      this.$emit("click");
     }
   }
 };


### PR DESCRIPTION
I realized that when you declare the base-switch, and you want to use the @click inside the tag for calling a method it won't work. Adding the expression: this.$emit("click"), will fix this.